### PR TITLE
Fixing MS4525do additions

### DIFF
--- a/flight_code/CMakeLists.txt
+++ b/flight_code/CMakeLists.txt
@@ -226,6 +226,8 @@ add_executable(flight
 	flight/datalog.cc
 	flight/telem.cc
 	flight/analog.cc
+	flight/ms4525_src/ms4525do.cc
+	# flight/ms4525_src/ms4525do.h
 	${PROTO_SRCS}
 	${PROTO_HDRS}
 )

--- a/flight_code/flight/datalog.cc
+++ b/flight_code/flight/datalog.cc
@@ -130,10 +130,10 @@ void DatalogAdd(const AircraftData &ref) {
   datalog_msg_.pres_diff_pres_pa = ref.sensor.diff_pres.pres_pa;
   datalog_msg_.pres_diff_die_temp_c = ref.sensor.diff_pres.die_temp_c;
   /* eigener Sensor*/
-  datalog_msg_.new_data = ref.sensor.edit_pres.new_data;
-  datalog_msg_.healthy = ref.sensor.edit_pres.healthy;
-  datalog_msg_.pres_pa = ref.sensor.edit_pres.pres_pa;
-  datalog_msg_.die_temp_c = ref.sensor.edit_pres.die_temp_c;
+  // datalog_msg_.new_data = ref.sensor.edit_pres.new_data;
+  // datalog_msg_.healthy = ref.sensor.edit_pres.healthy;
+  // datalog_msg_.pres_pa = ref.sensor.edit_pres.pres_pa;
+  // datalog_msg_.die_temp_c = ref.sensor.edit_pres.die_temp_c;
   /* Analog data */
   for (std::size_t i = 0; i < NUM_AIN_PINS; i++) {
     datalog_msg_.adc_volt[i] = ref.sensor.adc.volt[i];

--- a/flight_code/flight/ms4525_src/ms4525do.cc
+++ b/flight_code/flight/ms4525_src/ms4525do.cc
@@ -24,12 +24,12 @@
 */
 
 #include "ms4525do.h"  // NOLINT
-#if defined(ARDUINO)
-/*#include "Arduino.h"
-#include "Wire.h"*/
-#else
+// #if defined(ARDUINO)
+// /*#include "Arduino.h"
+// #include "Wire.h"*/
+// #else
 #include "core/core.h"
-#endif
+// #endif
 
 namespace bfs {
 

--- a/flight_code/flight/ms4525_src/ms4525do.h
+++ b/flight_code/flight/ms4525_src/ms4525do.h
@@ -26,13 +26,14 @@
 #ifndef MS4525_SRC_MS4525_H_  // NOLINT
 #define MS4525_SRC_MS4525_H_
 
-#if defined(ARDUINO)
-/*#include "Arduino.h"
-#include "Wire.h"*/
-#else
+// #if defined(ARDUINO)
+// /*#include "Arduino.h"
+// #include "Wire.h"*/
+// #else
+#include <cstdint>
 #include "core/core.h"
-#include "include/flight/additional_pressure.h"
-#endif
+#include "flight/additional_pressure.h"
+// #endif
 
 namespace bfs {
 

--- a/flight_code/include/flight/additional_pressure.h
+++ b/flight_code/include/flight/additional_pressure.h
@@ -3,6 +3,9 @@
 #include <optional>
 #include "core/core.h"
 
+#ifndef FLIGHT_CODE_INCLUDE_FLIGHT_ADDITIONAL_PRESSURE_H_
+#define FLIGHT_CODE_INCLUDE_FLIGHT_ADDITIONAL_PRESSURE_H_
+
 namespace bfs {
 
 struct PresEditConfig {
@@ -21,3 +24,5 @@ struct PresEditData {
 
 
 }  // namespace bfs
+
+#endif  // FLIGHT_CODE_INCLUDE_FLIGHT_ADDITIONAL_PRESSURE_H_


### PR DESCRIPTION
1. Added MS4525do source file to CMakeLists.txt
2. Fixed includes in MS4525do header and source files
3. Added header guards to additional_pressure.h
4. Commented out new pressure fields from datalog.cc - these were not being populated by the proto file

There are now errors with the MS4525do header and source files - trying to use methods that aren't defined, etc. Once those are cleaned up, it should work.